### PR TITLE
Allow to set the desired default language

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -25,6 +25,11 @@ BASE_URL=https://localhost
 # If hosting on a domain then put that here eg. log.m0spf.uk
 APP_HOSTNAME=log.local
 
+# The application default language. It will be set only if the language directory exists.
+# Visit https://github.com/magicbug/Cloudlog/tree/master/application/language to see available
+# languages
+LANGUAGE=english
+
 # Set what ports the proxy should listen on (note for letsencrypt to work these must be 80,443)
 HTTP_PORT=80
 HTTPS_PORT=443

--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,8 @@ CONFIGFILE=/data/cloudlog/application/config/config.php
 SAMPLE_CONFIGFILE=/data/cloudlog/application/config/config.sample.php
 DBCONFIGFILE=/data/cloudlog/application/config/database.php
 SAMPLE_DBCONFIGFILE=/data/cloudlog/application/config/database.sample.php
+LANGUAGE_DIR="$DIR/data/cloudlog/application/language/$LANGUAGE"
+
 if [ -f $DIR/${SAMPLE_CONFIGFILE} ]; then
     # Copy template
     cp $DIR/${SAMPLE_CONFIGFILE} $DIR/${CONFIGFILE}
@@ -70,6 +72,10 @@ if [ -f $DIR/${SAMPLE_CONFIGFILE} ]; then
         docker run -it --name install_worker --mount type=bind,source=$DIR/data/,target=/data --rm php:7-fpm sed -ri "s|\['base_url'\] = '([^\']*)+'\;|\['base_url'\] = '${BASE_URL}:${HTTPS_PORT}'\;|g" ${CONFIGFILE}
     fi
     docker run -it --name install_worker --mount type=bind,source=$DIR/data/,target=/data --rm php:7-fpm sed -ri "s|\['directory'\] = '([^\']*)+'\;|\['directory'\] = '${WEB_DIRECOTRY}'\;|g" ${CONFIGFILE}
+
+    if [ ${LANGUAGE} != "english" ] && [ -d "$LANGUAGE_DIR" ]; then
+        docker run -it --name install_worker --mount type=bind,source=$DIR/data/,target=/data --rm php:7-fpm sed -ri "s/\['language'\][[:space:]]=.*\;/\['language'\] = '${LANGUAGE}'\;/g" ${CONFIGFILE}
+    fi
 
     docker run -it --name install_worker --mount type=bind,source=$DIR/data/,target=/data --rm php:7-fpm sed -ri "s/\['callbook'\] = \"([^\']*)+\"\;/\['callbook'\] = \"${CALLBOOK:-hamqth}\"\;/g" ${CONFIGFILE}
     docker run -it --name install_worker --mount type=bind,source=$DIR/data/,target=/data --rm php:7-fpm sed -ri "s/\['hamqth_username'\] = \"([^\']*)+\"\;/\['hamqth_username'\] = \"${HAMQTH_USERNAME//\//\\/}\"\;/g" ${CONFIGFILE}

--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,10 @@ if [ -f $DIR/${SAMPLE_CONFIGFILE} ]; then
 
     if [ ${LANGUAGE} != "english" ] && [ -d "$LANGUAGE_DIR" ]; then
         docker run -it --name install_worker --mount type=bind,source=$DIR/data/,target=/data --rm php:7-fpm sed -ri "s/\['language'\][[:space:]]=.*\;/\['language'\] = '${LANGUAGE}'\;/g" ${CONFIGFILE}
+    else
+      echo ""
+      echo "*** WARNING - Default language not changed: looks like '${LANGUAGE}' is not an available language."
+      echo ""
     fi
 
     docker run -it --name install_worker --mount type=bind,source=$DIR/data/,target=/data --rm php:7-fpm sed -ri "s/\['callbook'\] = \"([^\']*)+\"\;/\['callbook'\] = \"${CALLBOOK:-hamqth}\"\;/g" ${CONFIGFILE}


### PR DESCRIPTION
By adding a `LANGUAGE` env to set the default language in the `config.php` file now that Cloudlog [is adding support to be translated](https://github.com/magicbug/Cloudlog/discussions/795).

The given value must match with an [available language](https://github.com/magicbug/Cloudlog/tree/master/application/language); otherwise, the default language will not be changed.