### PR TITLE
Fix AUTO_BACKUPS env in .env.sample file

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -65,7 +65,7 @@ LOTW_UPLOAD_CRON=true
 
 # Automatically backup database and cloudlog every night
 # Backups stored in ./data/backup directory
-AUTO_BACKUP=true
+AUTO_BACKUPS=true
 
 # Redis config
 # Redis is currently broken with cloudlog


### PR DESCRIPTION
Today, I noticed that auto backups were not being performed. After check it out, I found that an "S" is missing ni the .env.sample file.

https://github.com/tx44/cloudlog-docker/blob/e2ea95fc371320c9b0dbf4ee5d17a33e7f5f29e4/install.sh#L135-L137